### PR TITLE
Serial killerz

### DIFF
--- a/scripts/logBytes.py
+++ b/scripts/logBytes.py
@@ -1,0 +1,39 @@
+# Simple program to read in bytes from UART and write out to file
+# Default file name is LED_values.txt
+# Baud rate defaults to 115200
+# SJG for CS6780 Mar2023
+
+from datetime import datetime
+import serial
+
+
+def read_data(path, baud_rate, port_name):
+    # Open file
+    now = datetime.now()
+    f = open(path + "LED_values.txt", "a", encoding="ascii")
+    f.write("Trial " + now.strftime("%d/%m/%Y_%H:%M:%S") + "\n")
+
+    # Configure + open serial instance
+    ser = serial.Serial(port='/dev/ttyAMA0', baudrate=115200)
+    ser.open()
+
+    # Idiot check
+    if ser.is_open:
+        print("Successfully opened port to Disco \n")
+        byte = ser.readline()
+        print("Read a byte\n")
+        f.write(byte)
+    else:
+        print("Could not interface with Disco... shutting down \n")
+        f.write("Could not successfully open serial communication with port " + port_name + "at rate " + baud_rate)
+
+    # Close port and file
+    f.close()
+    ser.close()
+
+
+if __name__ == '__main__':
+    dir = "/home/whiskers/Documents/"
+    br = 115200
+    pn = "/dev/ttyAMA0"
+    read_data(dir, br, pn)

--- a/scripts/logBytes.py
+++ b/scripts/logBytes.py
@@ -6,6 +6,9 @@
 from datetime import datetime
 import serial
 
+# Functioning command:
+# screen /dev/ttyUSB0 115200
+
 
 def read_data(path, baud_rate, port_name):
     # Open file
@@ -14,15 +17,13 @@ def read_data(path, baud_rate, port_name):
     f.write("Trial " + now.strftime("%d/%m/%Y_%H:%M:%S") + "\n")
 
     # Configure + open serial instance
-    ser = serial.Serial(port='/dev/ttyAMA0', baudrate=115200)
-    ser.open()
+    ser = serial.Serial(port=port_name, baudrate=baud_rate)
 
-    # Idiot check
     if ser.is_open:
         print("Successfully opened port to Disco \n")
-        byte = ser.readline()
+        byte = ser.read()
         print("Read a byte\n")
-        f.write(byte)
+        f.write('{}'.format(int.from_bytes(byte,"big")))
     else:
         print("Could not interface with Disco... shutting down \n")
         f.write("Could not successfully open serial communication with port " + port_name + "at rate " + baud_rate)
@@ -35,5 +36,5 @@ def read_data(path, baud_rate, port_name):
 if __name__ == '__main__':
     dir = "/home/whiskers/Documents/"
     br = 115200
-    pn = "/dev/ttyAMA0"
+    pn = "/dev/ttyUSB0"
     read_data(dir, br, pn)


### PR DESCRIPTION
# changes that made the difference!
- `serial.Serial(port=port_name, baudrate=baud_rate)` opens port. 
   - $\therefore$ `ser.open()` failed due to recently-opened port.
- `ser.readline()` waits for `\n` (newline)
   - $\therefore \rightarrow$ `serial.read()`
- `f.write()` wrote a byte, which was stored as `b'a'`
   - $\therefore \rightarrow$ `f.write('{}'.format(int.from_bytes(byte,"big")))`
- `pn = "/dev/ttyUSB0"`

Thanks again for championing it, Stephanie! It really only took a few simple tweaks to finish out strong. I feel bad because you did all the heavy lifting. 